### PR TITLE
Add MyTestComp component for content display

### DIFF
--- a/src/components/MyTestComp.tsx
+++ b/src/components/MyTestComp.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+type Props = {
+  content: string;
+};
+
+const MyComp = (props: Props) => {
+  const { content } = props;
+  return <div>{content}</div>;
+};
+
+export default MyComp;


### PR DESCRIPTION
## Summary

This PR introduces a new reusable React component `MyTestComp` that provides a simple way to display content in a div wrapper. The component follows TypeScript best practices with proper type definitions and clean implementation.

## Changes

- **Added** `src/components/MyTestComp.tsx`
  - New React functional component with TypeScript support
  - Accepts `content` prop of type string
  - Renders content within a div element
  - Properly exported as default export
  - Follows project's component structure and naming conventions

## How to Test

1. Import the component: `import MyTestComp from 'src/components/MyTestComp'`
2. Use in JSX: `<MyTestComp content="Your test content here" />`
3. Verify that the content is rendered correctly in a div element
4. Test with different string values to ensure proper prop handling

## Related Issues / Tickets

N/A - Component addition for development purposes